### PR TITLE
add chatId and user extraction to Session middleware

### DIFF
--- a/src/main/java/org/slyrack/telegrambots/DefaultConfig.java
+++ b/src/main/java/org/slyrack/telegrambots/DefaultConfig.java
@@ -1,11 +1,13 @@
 package org.slyrack.telegrambots;
 
+import org.slyrack.telegrambots.Middleware.GeneralInfoExtractorMiddleware;
 import org.slyrack.telegrambots.session.ChatIdSessionIdGenerator;
 import org.slyrack.telegrambots.session.InMemorySessionManager;
 import org.slyrack.telegrambots.session.SessionIdGenerator;
 import org.slyrack.telegrambots.session.SessionManager;
 import org.slyrack.telegrambots.state.InMemoryStateManager;
 import org.slyrack.telegrambots.state.StateManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -35,5 +37,11 @@ public class DefaultConfig {
     @ConditionalOnMissingBean(value = SessionManager.class)
     public SessionManager sessionManager(final SlyrackProperties properties) {
         return new InMemorySessionManager(properties.getSessionTtlMillis());
+    }
+
+    @Bean
+    @ConditionalOnExpression("${slyrack.middleware.generalInfo} == true and ${slyrack.enableSessionManagement} == true")
+    public GeneralInfoExtractorMiddleware generalInfoExtractorMiddleware(){
+        return new GeneralInfoExtractorMiddleware();
     }
 }

--- a/src/main/java/org/slyrack/telegrambots/Middleware/GeneralInfoExtractorMiddleware.java
+++ b/src/main/java/org/slyrack/telegrambots/Middleware/GeneralInfoExtractorMiddleware.java
@@ -1,0 +1,42 @@
+package org.slyrack.telegrambots.Middleware;
+
+import org.slyrack.telegrambots.annotations.MiddleHandler;
+import org.slyrack.telegrambots.session.Session;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * extract:
+ * <ul>
+ *     <li>chat-id</li>
+ *     <li>user</li>
+ * </ul>
+ * from telegram update
+ */
+public class GeneralInfoExtractorMiddleware {
+
+    @MiddleHandler
+    public void configureSession(final Update update, final Session session) {
+        if (session == null)
+            return;
+
+        if (!session.containsAttribute(SupportAttribute.CHAT_ID.attributeName))
+            UpdateInfoExtractor.getChatId(update)
+                    .ifPresent(chatId -> session.setAttribute(SupportAttribute.CHAT_ID.attributeName, String.valueOf(chatId)));
+
+        if (!session.containsAttribute(SupportAttribute.USER.attributeName))
+            UpdateInfoExtractor.getUser(update)
+                    .ifPresent(user -> session.setAttribute(SupportAttribute.USER.attributeName, user));
+    }
+
+    public enum SupportAttribute{
+        CHAT_ID("chat-id"),
+        USER("user");
+
+        final String attributeName;
+
+        SupportAttribute(String attributeName){
+            this.attributeName = attributeName;
+        }
+    }
+
+}

--- a/src/main/java/org/slyrack/telegrambots/Middleware/UpdateInfoExtractor.java
+++ b/src/main/java/org/slyrack/telegrambots/Middleware/UpdateInfoExtractor.java
@@ -1,0 +1,65 @@
+package org.slyrack.telegrambots.Middleware;
+
+import org.slyrack.telegrambots.flags.UpdateType;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.util.Optional;
+
+public class UpdateInfoExtractor {
+
+    public static Optional<User> getUser(final Update update) {
+        if (update == null) return Optional.empty();
+
+        if (UpdateType.MESSAGE.test(update))
+            return Optional.ofNullable(update.getMessage().getFrom());
+        else if (UpdateType.CALLBACK_QUERY.test(update))
+            return Optional.ofNullable(update.getCallbackQuery().getFrom());
+        else if (UpdateType.INLINE_QUERY.test(update))
+            return Optional.of(update.getInlineQuery().getFrom());
+        else if (UpdateType.CHANNEL_POST.test(update))
+            return Optional.ofNullable(update.getChannelPost().getFrom());
+        else if (UpdateType.EDITED_CHANNEL_POST.test(update))
+            return Optional.ofNullable(update.getEditedChannelPost().getFrom());
+        else if (UpdateType.EDITED_MESSAGE.test(update))
+            return Optional.ofNullable(update.getEditedMessage().getFrom());
+        else if (UpdateType.CHOSEN_INLINE_RESULT.test(update))
+            return Optional.of(update.getChosenInlineQuery().getFrom());
+        else if (UpdateType.SHIPPING_QUERY.test(update))
+            return Optional.ofNullable(update.getShippingQuery().getFrom());
+        else if (UpdateType.PRE_CHECKOUT_QUERY.test(update))
+            return Optional.ofNullable(update.getPreCheckoutQuery().getFrom());
+        else if (UpdateType.POLL_ANSWER.test(update))
+            return Optional.ofNullable(update.getPollAnswer().getUser());
+        else
+            return Optional.empty();
+    }
+
+    public static Optional<Long> getChatId(final Update update) {
+        if (update == null) return Optional.empty();
+
+        if (UpdateType.MESSAGE.test(update))
+            return Optional.ofNullable(update.getMessage().getChatId());
+        else if (UpdateType.CALLBACK_QUERY.test(update))
+            return Optional.ofNullable(update.getCallbackQuery().getMessage().getChatId());
+        else if (UpdateType.INLINE_QUERY.test(update))
+            return Optional.of(update.getInlineQuery().getFrom().getId());
+        else if (UpdateType.CHANNEL_POST.test(update))
+            return Optional.ofNullable(update.getChannelPost().getChatId());
+        else if (UpdateType.EDITED_CHANNEL_POST.test(update))
+            return Optional.ofNullable(update.getEditedChannelPost().getChatId());
+        else if (UpdateType.EDITED_MESSAGE.test(update))
+            return Optional.ofNullable(update.getEditedMessage().getChatId());
+        else if (UpdateType.CHOSEN_INLINE_RESULT.test(update))
+            return Optional.of(update.getChosenInlineQuery().getFrom().getId());
+        else if (UpdateType.SHIPPING_QUERY.test(update))
+            return Optional.of(update.getShippingQuery().getFrom().getId());
+        else if (UpdateType.PRE_CHECKOUT_QUERY.test(update))
+            return Optional.of(update.getPreCheckoutQuery().getFrom().getId());
+        else if (UpdateType.POLL_ANSWER.test(update))
+            return Optional.of(update.getPollAnswer().getUser().getId());
+        else
+            return Optional.empty();
+    }
+
+}


### PR DESCRIPTION
close #11 

add middleware that allow to access general info from update (chatId, user)

this middleware used only if the option slyrack.middleware.generalInfo set to true